### PR TITLE
Removing Multi-Stage Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.10.3-alpine3.7 AS build
+FROM docker.io/golang:1.10.3-alpine3.7
 
 # Install required tools for the project (both to build and to run). This is the requirements section
 # Run `trash --file vendor.yaml` to get application dependencies
@@ -9,13 +9,3 @@ COPY . /go/src/github.com/tqoliver/grogar/
 WORKDIR /go/src/github.com/tqoliver/grogar/
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /grogar
-
-# scratch is the smallest available container size
-FROM scratch
-# RUN apk update && apk add curl && apk add mysql-client && apk add sudo \
-#        && addgroup -g 1001 -S exampleapp \
-#        && adduser -u 1001 -D -S -G exampleapp exampleapp
-COPY --from=build /grogar /
-EXPOSE 8000
-USER 1001
-ENTRYPOINT [ "/grogar" ]


### PR DESCRIPTION
Deploy to OpenShift with the following:

Create a new project
`oc new-project grogar`

Create a new image stream
`oc create is grogar-artifact`

Stage 1 Build: Create a build configuration for the builder
```
oc new-build https://github.com/cricci82/grogar --name=builder \
  --to=grogar-artifact:latest
```

Stage 2 Build: Create a build configuration for the runtime
```
oc new-build --name=runtime \
   --docker-image=scratch \
   --source-image=grogar-artifact \
   --source-image-path=/grogar:. \
   --dockerfile=$'FROM scratch\nCOPY /grogar /\nEXPOSE 8080\nUSER 1001\nENTRYPOINT ["/grogar"]'
```